### PR TITLE
build(deps): bump UnityEditor from `2020.3.15f2` to `2022.1.7f1`

### DIFF
--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.15f2
-m_EditorVersionWithRevision: 2020.3.15f2 (6cf78cb77498)
+m_EditorVersion: 2022.1.7f1
+m_EditorVersionWithRevision: 2022.1.7f1 (240f4c1f462c)


### PR DESCRIPTION
Bumps the [Unity Editor](https://unity3d.com/get-unity/download) version from `2020.3.15f2 (6cf78cb77498)` to `2022.1.7f1 (240f4c1f462c)`.

- [Release notes](https://unity3d.com/get-unity/download/archive)