### PR TITLE
build(deps): bump com.unity.2d.spriteshape from `4.0.0` to `9.0.0-pre.1`

### DIFF
--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,1 @@
-m_EditorVersion: 2020.3.15f2
-m_EditorVersionWithRevision: 2020.3.15f2 (6cf78cb77498)
+{"dependencies":{"com.inklestudios.ink-unity-integration":"1.0.0","com.unity.2d.spriteshape":"9.0.0-pre.1","com.unity.2d.tilemap":"100.0.0","com.neuecc.unirx":"200.0.0"},"scopedRegistries":[{"name":"OpenUPM","url":"https://package.openupm.com","scopes":["com.inklestudios.ink-unity-integration","com.neuecc.unirx"]}],"testables":["com.unity.inputsystem"]}


### PR DESCRIPTION
Bumps the version of `com.unity.2d.spriteshape` version from `4.0.0` to `9.0.0-pre.1`.<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"com.unity.2d.spriteshape","version":"9.0.0-pre.1"}} -->