### PR TITLE
build(deps): bump `com.inklestudios.ink-unity-integration` from `1.0.0` to `1.0.2`

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,6 @@
 {
   "dependencies": {
-    "com.inklestudios.ink-unity-integration": "1.0.0",
-    "com.unity.2d.spriteshape": "4.0.0",
-    "com.unity.2d.pixel-perfect": "100.0.0",
-    "com.neuecc.unirx": "200.0.0"
+    "com.inklestudios.ink-unity-integration": "1.0.2"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
Bumps the version of `com.inklestudios.ink-unity-integration` version from `1.0.0` to `1.0.2`.<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"com.inklestudios.ink-unity-integration","version":"1.0.2"}} -->