### PR TITLE
build(deps): bump `com.unity.2d.spriteshape` from `4.0.0` to `8.0.0`

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,6 @@
 {
   "dependencies": {
-    "com.inklestudios.ink-unity-integration": "1.0.0",
-    "com.unity.2d.spriteshape": "4.0.0",
-    "com.unity.2d.pixel-perfect": "100.0.0",
-    "com.neuecc.unirx": "200.0.0"
+    "com.unity.2d.spriteshape": "8.0.0"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
Bumps the version of `com.unity.2d.spriteshape` version from `4.0.0` to `8.0.0`.<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"com.unity.2d.spriteshape","version":"8.0.0"}} -->