### PR TITLE
build(deps): bump UnityEditor from `2020.3.15f2` to `2022.2.0a18`

### DIFF
--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.15f2
-m_EditorVersionWithRevision: 2020.3.15f2 (6cf78cb77498)
+m_EditorVersion: 2022.2.0a18
+m_EditorVersionWithRevision: 2022.2.0a18 (e38c507fabd4)


### PR DESCRIPTION
Bumps the [Unity Editor](https://unity3d.com/get-unity/download) version from `2020.3.15f2 (6cf78cb77498)` to `2022.2.0a18 (e38c507fabd4)`.

- [Alpha release notes](https://unity3d.com/beta/2022.1b#:~:text=Latest%20version-,Release%20notes,-Archive)

<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"editor","version":"2022.2.0a18 (e38c507fabd4)"}} -->