### PR TITLE
build(deps): bump `com.unity.ide.rider` from `2.0.7` to `3.0.15`

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,6 @@
 {
   "dependencies": {
-    "com.inklestudios.ink-unity-integration": "1.0.0",
-    "com.neuecc.unirx": "200.0.0",
-    "com.unity.ide.rider": "2.0.7",
-    "com.unity.ide.visualstudio": "100.0.0"
+    "com.unity.ide.rider": "3.0.15"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
Bumps the version of `com.unity.ide.rider` version from `2.0.7` to `3.0.15`.<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"com.unity.ide.rider","version":"3.0.15"}} -->