### PR TITLE
build(deps): bump `com.unity.localization` from `1.0.0` to `1.3.1`

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,9 +1,6 @@
 {
   "dependencies": {
-    "com.inklestudios.ink-unity-integration": "1.0.0",
-    "com.neuecc.unirx": "200.0.0",
-    "com.unity.localization": "1.0.0",
-    "com.unity.ide.visualstudio": "100.0.0"
+    "com.unity.localization": "1.3.2"
   },
   "scopedRegistries": [
     {


### PR DESCRIPTION
Bumps the version of `com.unity.localization` version from `1.0.0` to `1.3.1`.<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"com.unity.localization","version":"1.3.1"}} -->