### PR TITLE
build(deps): bump UnityEditor from `2020.3.15f2` to `2022.1.19f1`

### DIFF
--- a/subfolder/ProjectSettings/ProjectVersion.txt
+++ b/subfolder/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.15f2
-m_EditorVersionWithRevision: 2020.3.15f2 (6cf78cb77498)
+m_EditorVersion: 2022.1.19f1
+m_EditorVersionWithRevision: 2022.1.19f1 (2fd7b40534d1)


### PR DESCRIPTION
Bumps the [Unity Editor](https://unity3d.com/get-unity/download) version from `2020.3.15f2 (6cf78cb77498)` to `2022.1.19f1 (2fd7b40534d1)`.

- [Release notes](https://unity3d.com/get-unity/download/archive)

<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"editor","version":"2022.1.19f1 (2fd7b40534d1)"}} -->