### PR TITLE
build(deps): bump UnityEditor from `2020.3.15f2` to `2021.3.15f1`

### DIFF
--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.15f2
-m_EditorVersionWithRevision: 2020.3.15f2 (6cf78cb77498)
+m_EditorVersion: 2021.3.15f1
+m_EditorVersionWithRevision: 2021.3.15f1 (e8e88683f834)


### PR DESCRIPTION
Bumps the [Unity Editor](https://unity3d.com/get-unity/download) version from `2020.3.15f2 (6cf78cb77498)` to `2021.3.15f1 (e8e88683f834)`.

- [Release notes](https://unity3d.com/get-unity/download/archive)

<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"editor","version":"2021.3.15f1 (e8e88683f834)"}} -->