### PR TITLE
build(deps): bump UnityEditor from `2020.3.15f2` to `2023.3.0b5`

### DIFF
--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.15f2
-m_EditorVersionWithRevision: 2020.3.15f2 (6cf78cb77498)
+m_EditorVersion: 2023.3.0b5
+m_EditorVersionWithRevision: 2023.3.0b5 (30acc77e9b6b)


### PR DESCRIPTION
Bumps the [Unity Editor](https://unity3d.com/get-unity/download) version from `2020.3.15f2 (6cf78cb77498)` to `2023.3.0b5 (30acc77e9b6b)`.

- [Beta release notes](https://unity3d.com/beta/2022.1b#:~:text=Latest%20version-,Release%20notes,-Archive)

<!--uvb {"type":"unity-version-bump","version":1,"data":{"package":"editor","version":"2023.3.0b5 (30acc77e9b6b)"}} -->